### PR TITLE
Fixes the Device Authorization Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ poetry install
 Set the scopes that you want to request:
 
 ```sh
-export EDUTEAMS_SCOPE="openid+profile"
+export EDUTEAMS_SCOPE="openid profile"
 ```
 
 Set the client id of your application:


### PR DESCRIPTION
According to the [RFC8628][1], the client initiates the authorization
flow by requesting a set of verification codes from the authorization
server by making an HTTP "POST" request to the device authorization
endpoint.

[1]: https://datatracker.ietf.org/doc/html/rfc8628